### PR TITLE
Fix TTIAR, tracking recent Rakudo change

### DIFF
--- a/lib/XML/Canonical.pm6
+++ b/lib/XML/Canonical.pm6
@@ -151,7 +151,7 @@ sub _needed_attribute($xml, $key) {
         my @keyparts = $key.split(/\:/);
         @keyparts[1] ||= '';
 
-        return False if($xml.parent.nsURI(@keyparts[1]) eq $value);
+        return False if ($xml.parent.nsURI(@keyparts[1]) eq $value);
         return True;
     }
 }


### PR DESCRIPTION
Whitespace is now required after keywords
