### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/XML/Canonical.pm6
+++ b/lib/XML/Canonical.pm6
@@ -1,6 +1,6 @@
 use XML;
 
-module XML::Canonical;
+unit module XML::Canonical;
 
 our proto canonical(|) is export { * };
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
